### PR TITLE
Add Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
         'Framework :: Django',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',


### PR DESCRIPTION
Additionally, declare explicit support for Python 3 only.