### PR TITLE
install django.contrib.sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
 ]
 
 PEREGRINE_APPS = [
+    'django.contrib.sites',
     'wagtail.wagtailcore',
     'wagtail.wagtailadmin',
     'wagtail.wagtaildocs',


### PR DESCRIPTION
`django.contrib.sites` isn't installed by `django-admin startproject` but Wagtail's migrations won't run without it.