### PR TITLE
Update to support Wagtail >=2.9, access to request site api has changed

### DIFF
--- a/peregrine/templatetags/peregrine.py
+++ b/peregrine/templatetags/peregrine.py
@@ -1,7 +1,10 @@
 from django import template
 from django.conf import settings
 
+from wagtail.core.models import Site
+
 from ..models import SitePost
+
 
 register = template.Library()
 
@@ -12,7 +15,7 @@ def get_site_root(context):
     NB this returns a core.Page, not the implementation-specific model used
     so object-comparison to self will return false as objects would differ
     """
-    return context['request'].site.root_page
+    return Site.find_for_request(context['request']).root_page
 
 
 def has_menu_children(page):

--- a/peregrine/views.py
+++ b/peregrine/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.views.generic import ListView
 
+from wagtail.core.models import Site
 from wagtail.core.views import serve
 
 from .models import SitePost, PeregrineSettings
@@ -18,7 +19,7 @@ class PostsListView(ListView):
         return SitePost.objects.live().order_by('-post_date')
 
     def get(self, request, *args, **kwargs):
-        peregrine_settings = PeregrineSettings.for_site(request.site)
+        peregrine_settings = PeregrineSettings.for_site(Site.find_for_request(request))
 
         if peregrine_settings.landing_page is None or 'name' in kwargs:
             # If a landing page hasn't been set, or 'name' is in kwargs
@@ -33,7 +34,7 @@ class PostsListView(ListView):
             return serve(request, peregrine_settings.landing_page.url)
 
     def get_paginate_by(self, queryset):
-        peregrine_settings = PeregrineSettings.for_site(self.request.site)
+        peregrine_settings = PeregrineSettings.for_site(Site.find_for_request(self.request))
 
         return peregrine_settings.post_number
 
@@ -81,7 +82,7 @@ class PostsFeed(Feed):
     )
 
     def get_object(self, request, *args, **kwargs):
-        kwargs['count'] = PeregrineSettings.for_site(request.site).post_number_rss
+        kwargs['count'] = PeregrineSettings.for_site(Site.find_for_request(request.site)).post_number_rss
         return kwargs['count']
 
     def items(self, count):

--- a/peregrine/wagtail_hooks.py
+++ b/peregrine/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.db import connection
 
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
+from wagtail.core.models import Site
 
 from .models import Category, PeregrineSettings
 
@@ -27,7 +28,7 @@ def delete_old_revisions(request, page):
     revisions.
     """
 
-    peregrine_settings = PeregrineSettings.for_site(request.site)
+    peregrine_settings = PeregrineSettings.for_site(Site.find_for_request(request))
 
     if peregrine_settings.revisions_to_keep is not None:
         pks_to_delete = page.revisions.order_by('-created_at')[peregrine_settings.revisions_to_keep:].values_list('id', flat=True)


### PR DESCRIPTION
Fixes #11 
SiteMiddleware and request.site deprecated in Wagtail 2.9
https://docs.wagtail.io/en/stable/releases/2.9.html#sitemiddleware-and-request-site-deprecated